### PR TITLE
[XCS-106] Typo of emstype property to support Physical Infra Manager icons

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   require_nested :RefreshWorker
 
   def self.ems_type
-    @ems_type ||= "lenovo_ph_infra".freeze
+    @ems_type ||= "lenovo".freeze
   end
 
   def self.description

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   require_nested :RefreshWorker
 
   def self.ems_type
-    @ems_type ||= "lenovo".freeze
+    @ems_type ||= "lenovo_ph_infra".freeze
   end
 
   def self.description

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -78,21 +78,22 @@ module ManageIQ::Providers::Lenovo
     def parse_nodes(node)
       # physical_server = ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer.new(node)
       new_result = {
-        :type    => ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer.name,
-        :name    => node.name,
-        :ems_ref => @ems.uid_ems,
-        :uid_ems => @ems.uid_ems,
-        :hostname => node.hostname,
-        :productName => node.productName,
-        :manufacturer => node.manufacturer,
-        :machineType => node.machineType,
-        :model  => node.model,
-        :serialNumber => node.serialNumber,
-        :uuid =>  node.uuid,
-        :FRU  =>  node.FRU,
-        :macAddresses => node.macAddress.split(",").flatten,
-        :ipv4Addresses => node.ipv4Addresses.split.flatten,
-        :ipv6Addresses => node.ipv6Addresses.split.flatten
+        :type           => ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer.name,
+        :name           => node.name,
+        :ems_ref        => @ems.uid_ems,
+        :uid_ems        => @ems.uid_ems,
+        :hostname       => node.hostname,
+        :productName    => node.productName,
+        :manufacturer   => node.manufacturer,
+        :machineType    => node.machineType,
+        :model          => node.model,
+        :serialNumber   => node.serialNumber,
+        :uuid           => node.uuid,
+        :FRU            => node.FRU,
+        :macAddresses   => node.macAddress.split(",").flatten,
+        :ipv4Addresses  => node.ipv4Addresses.split.flatten,
+        :ipv6Addresses  => node.ipv6Addresses.split.flatten,
+        :healthState   => node.cmmHealthState
       }
       return node.uuid, new_result
     end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -40,10 +40,17 @@ module ManageIQ::Providers::Lenovo
 
       $log.info("#{log_header}...")
 
-      get_physical_servers
-
+      auth = @ems.authentications.first
+    
+      auth.status = "None"
+      begin
+        get_physical_servers
+        auth.status = "Valid"
+      rescue
+        auth.status = "Invalid"
+      end
       $log.info("#{log_header}...Complete")
-
+      auth.save!
       @data
     end
 

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -113,7 +113,7 @@ module ManageIQ::Providers::Lenovo
         :ipv4Addresses  => node.ipv4Addresses.split.flatten,
         :ipv6Addresses  => node.ipv6Addresses.split.flatten,
         :healthState    => HEALTH_STATE[node.cmmHealthState.downcase],
-        :powerState     => POWER_STATE_MAP[node.powerStatus.downcase],
+        :powerState     => POWER_STATE_MAP[node.powerStatus],
         :vendor         => "lenovo"
       }
       return node.uuid, new_result


### PR DESCRIPTION
Changes value of `emstype` property to `"lenovo"` instead `"lenovo_ph_infra"`